### PR TITLE
로그인 시 이미 가입한 유저의 경우도 다음창(SubActivity)으로 넘어갈 수 있게 수정

### DIFF
--- a/app/src/main/java/com/example/front_ui/LoginActivity.kt
+++ b/app/src/main/java/com/example/front_ui/LoginActivity.kt
@@ -9,22 +9,31 @@ import com.example.front_ui.Util_Kotlin.Firestore
 import com.firebase.ui.auth.AuthUI
 import com.firebase.ui.auth.ErrorCodes
 import com.firebase.ui.auth.IdpResponse
+import com.google.android.gms.auth.api.signin.GoogleSignIn
+import com.google.android.gms.auth.api.signin.GoogleSignInClient
 import com.google.android.gms.auth.api.signin.GoogleSignInOptions
 import com.google.android.gms.common.util.CollectionUtils.listOf
 import kotlinx.android.synthetic.main.activity_login.*
 import org.jetbrains.anko.*
 import org.jetbrains.anko.design.longSnackbar
 
+//앱을 실행시킬 시 가장 처음으로 나오는 창입니다.(로그인 및 회원가입 담당)
 class LoginActivity : AppCompatActivity() {
 
-    val googleSignInOption = GoogleSignInOptions.Builder(GoogleSignInOptions.DEFAULT_SIGN_IN)
-            .requestEmail().build()
+    private val TAG = "TAG_LoginActivity"
     private val signInProviders =
-            listOf(AuthUI.IdpConfig.EmailBuilder().setAllowNewAccounts(true).setRequireName(true).build(),
-                    AuthUI.IdpConfig.PhoneBuilder().build(),
-                    AuthUI.IdpConfig.GoogleBuilder()
-                            .setSignInOptions(googleSignInOption)
-                            .build())
+            listOf(
+                    AuthUI.IdpConfig.EmailBuilder()
+                    .setAllowNewAccounts(true)
+                    .setRequireName(true)
+                    .build()
+//                    AuthUI.IdpConfig.PhoneBuilder()
+//                            .build()
+//                    AuthUI.IdpConfig.GoogleBuilder()
+//                            .setSignInOptions(googleSignInOption)
+//                            .build()
+
+            )
     val RC_AUTHUI_REQUEST_CODE = 1001
 
 
@@ -36,6 +45,7 @@ class LoginActivity : AppCompatActivity() {
             val intent =AuthUI.getInstance()
                     .createSignInIntentBuilder()
                     .setAvailableProviders(signInProviders)
+                    .setTheme(R.style.ThemeOverlay_AppCompat_Dark)
                     .build()
             startActivityForResult(intent, RC_AUTHUI_REQUEST_CODE)
         }
@@ -45,24 +55,33 @@ class LoginActivity : AppCompatActivity() {
         super.onActivityResult(requestCode, resultCode, data)
 
         if(requestCode == RC_AUTHUI_REQUEST_CODE){
+
             val response = IdpResponse.fromResultIntent(data)
+
             if(resultCode == Activity.RESULT_OK){
+
                 //여기서 로딩창을 켜줍니다.
                 val progressDialog = indeterminateProgressDialog("잠시만 기다려주세요...", "회원 정보 확인중")
+
                 Firestore.loginFirstTime {//여기서 onComplete()역할을 알 수 있다.(이 함수를 실행시키고 나서 이어서 할 이벤트를 적어주게 함.)
-                    startActivity(intentFor<MainActivity>().newTask().clearTask())//이건 단순히 MainActivitry로 넘어가는 intent입니다.
+                    startActivity(intentFor<SubActivity>().newTask().clearTask())//이건 단순히 MainActivitry로 넘어가는 intent입니다.
+                    Log.d(TAG, "로그인 완료(DB에 업로드 완료) 후 서브액티비티로 이동했습니다.")
                     progressDialog.dismiss()//로딩창을 꺼줍니다.
                 }
             }
             else if(resultCode == Activity.RESULT_CANCELED){
-                if(response == null) return
+
+                if(response == null) {
+                    return//아무것도 반환안함(결국 response가 null이면 아무일도 안일어남, 에러도 안 일어남)
+                }
+
                 when(response.error?.errorCode){
                     ErrorCodes.NO_NETWORK -> longSnackbar(relativeLayout(), "와이파이나 데이터를 연결해주세요.")
                     ErrorCodes.UNKNOWN_ERROR -> longSnackbar(relativeLayout(), "알 수 없는 에러")
                 }
             }
             else{
-                Log.d("LoginActivity", "결과 요청코드 에러")
+                Log.d(TAG, "결과 요청코드 에러")
             }
         }
     }

--- a/app/src/main/java/com/example/front_ui/Util_Kotlin/Firestore.kt
+++ b/app/src/main/java/com/example/front_ui/Util_Kotlin/Firestore.kt
@@ -6,18 +6,19 @@ import com.google.firebase.firestore.DocumentReference
 import com.google.firebase.firestore.FirebaseFirestore
 
 object Firestore {
-    private val firebaseAuthInstance : FirebaseAuth by lazy { FirebaseAuth.getInstance() }
+    private val firebaseAuthInstance: FirebaseAuth by lazy { FirebaseAuth.getInstance() }
     private val firestoreInstance: FirebaseFirestore by lazy { FirebaseFirestore.getInstance() }
     private val currentUserDocRef: DocumentReference
         get() = firestoreInstance.document(
-                "사용자/${FirebaseAuth.getInstance().uid ?: throw java.lang.NullPointerException("에러발생")}"
+                "사용자/${FirebaseAuth.getInstance().uid
+                        ?: throw java.lang.NullPointerException("에러발생")}"
         )
 
     //처음 로그인하는 유저에게 사용되는 메서드
-    fun loginFirstTime(onComplete : () -> Unit){
+    fun loginFirstTime(onComplete: () -> Unit) {
         currentUserDocRef.get().addOnSuccessListener {
             //만약 db에 현재 회원가입한 유저가 없다면(새로운 유저라면)
-            if(!it.exists()){
+            if (!it.exists()) {
                 //DB에 넣어줄 유저의 정보를 만들어준다.(회원가입 당시 프로필 설정과 좋아요 개수는 없으니 NULL과 0으로 초기값 설정)
                 val newUser = UserInfo(
                         firebaseAuthInstance.currentUser?.email.toString(),
@@ -30,6 +31,8 @@ object Firestore {
                     //이 경로로 새로운 유저 정보가 업로드에 성공했으면 onComplete()실행
                     onComplete()//반드시 괄호를 적어줘야합니다.(안적어주면 작동안함)
                 }
+            } else {//새로운 유저가 아니고 이미 가입된 유저의 경우는 바로 다음창으로 넘겨줌.
+                onComplete()
             }
         }
     }


### PR DESCRIPTION
1. [Firestore.object] loginFirstTime메서드
 : 새로운 유저가 아닌 이미 가입한 유저의 경우에도 다음창으로 넘어갈 수 있게 onComplete()추가해줌
2. [LoginActivity.kt] onActivityResult메서드
 : 다음창으로 넘어갈 때 MainActivity로 넘어가게 했는데 다시보니 SubActivity로 넘어가게 해야해서 수정해줌. 